### PR TITLE
Keep email setup stack mounted during onboarding

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,7 +7,6 @@ import { DatabaseProvider, useDatabase } from "@/contexts/DatabaseContext";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import { ContactsProvider } from "@/contexts/ContactsContext";
 import { OnboardingProvider, useOnboarding } from "@/contexts/OnboardingContext";
-import { AuthScreen } from "@/components/AuthScreen";
 import { View, Text, ActivityIndicator, StyleSheet } from "react-native";
 import { BackgroundTaskManager } from "@/services/BackgroundTaskManager";
 
@@ -15,9 +14,14 @@ SplashScreen.preventAutoHideAsync();
 
 const queryClient = new QueryClient();
 
-function RootLayoutNav() {
+type RootLayoutNavProps = {
+  initialRouteName: string;
+};
+
+function RootLayoutNav({ initialRouteName }: RootLayoutNavProps) {
   return (
-    <Stack screenOptions={{ headerBackTitle: "Back" }}>
+    <Stack initialRouteName={initialRouteName} screenOptions={{ headerBackTitle: "Back" }}>
+      <Stack.Screen name="auth" options={{ headerShown: false }} />
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="contact/[id]" options={{ headerShown: false }} />
       <Stack.Screen name="permissions" options={{ presentation: "modal", title: "Permissions" }} />
@@ -63,6 +67,9 @@ function AppContent() {
     }
 
     if (!isAuthenticated) {
+      if (pathname !== "/auth") {
+        router.replace("/auth");
+      }
       return;
     }
 
@@ -73,7 +80,10 @@ function AppContent() {
       if (!isInOnboardingFlow) {
         router.replace("/onboarding");
       }
-    } else if (pathname === "/onboarding") {
+      return;
+    }
+
+    if (pathname === "/onboarding" || pathname === "/auth") {
       router.replace("/(tabs)");
     }
   }, [
@@ -106,11 +116,13 @@ function AppContent() {
     );
   }
 
-  if (!isAuthenticated) {
-    return <AuthScreen />;
-  }
+  const initialRouteName = !isAuthenticated
+    ? 'auth'
+    : !isOnboardingCompleted
+      ? 'onboarding'
+      : '(tabs)';
 
-  return <RootLayoutNav />;
+  return <RootLayoutNav key={initialRouteName} initialRouteName={initialRouteName} />;
 }
 
 export default function RootLayout() {

--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { AuthScreen } from "@/components/AuthScreen";
+
+export default function AuthRoute() {
+  return <AuthScreen />;
+}


### PR DESCRIPTION
## Summary
- update the root stack to accept an initial route, add the /auth entry point, and keep onboarding/email setup screens registered while the app runs
- drive authentication and onboarding gating through navigation redirects so the stack stays mounted during setup
- surface the AuthScreen as a dedicated route to support the updated navigation flow

## Testing
- bun lint *(fails: expo CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad44305ac832e82f701cda32f0c52