### PR TITLE
Use static tcp socket require in ImapService

### DIFF
--- a/services/ImapService.ts
+++ b/services/ImapService.ts
@@ -595,7 +595,7 @@ export class ImapService {
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      this.transport = require(SOCKET_LIBRARY_NAME);
+      this.transport = require('react-native-tcp-socket') as TcpSocketModule;
       return this.transport;
     } catch (error) {
       const reason = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## Summary
- update ImapService to require the TCP socket module via a static string so Metro can resolve it

## Testing
- `bun lint` *(fails: expo: command not found)*
- `npx expo lint` *(fails: npm 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9e06d08832ea9c6280b881202a8