### PR TITLE
Fix TCP socket require usage for Metro bundler

### DIFF
--- a/services/ImapService.ts
+++ b/services/ImapService.ts
@@ -14,7 +14,7 @@ let transportInitializationError: Error | null = null;
 if (Platform.OS !== 'web') {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    cachedTransport = require(SOCKET_LIBRARY_NAME) as TcpSocketModule;
+    cachedTransport = require('react-native-tcp-socket') as TcpSocketModule;
   } catch (error) {
     const reason = error instanceof Error ? error.message : 'Unknown error';
     const message = `Failed to load ${SOCKET_LIBRARY_NAME}. Ensure the library is installed and linked. ${reason}`;


### PR DESCRIPTION
## Summary
- require the react-native-tcp-socket module using a string literal so Metro can include it while keeping the error messaging constant intact

## Testing
- `bunx expo lint` *(fails: GET https://registry.npmjs.org/expo - 403)*
- `bunx expo prebuild` *(fails: GET https://registry.npmjs.org/expo - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cb116d5ea0832e96f89cceef538065