### PR TITLE
Add TCP socket shim for ImapService

### DIFF
--- a/services/TcpSocketTransport.native.ts
+++ b/services/TcpSocketTransport.native.ts
@@ -1,0 +1,3 @@
+import * as TcpSocketTransport from 'react-native-tcp-socket';
+
+export default TcpSocketTransport;

--- a/services/TcpSocketTransport.web.ts
+++ b/services/TcpSocketTransport.web.ts
@@ -1,0 +1,3 @@
+const TcpSocketTransport = null;
+
+export default TcpSocketTransport;


### PR DESCRIPTION
## Summary
- add a platform-specific TcpSocketTransport shim that statically imports react-native-tcp-socket on native and returns null on web
- update ImapService to pull in the shim, centralize the load error message, and keep the existing caching/error handling behaviour

## Testing
- bun run lint *(fails: expo CLI is not available in the container)*
- npx expo lint *(fails: registry access is blocked in the container)*
- npx expo prebuild --no-install *(fails: registry access is blocked in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1416a62c832e9c4557f0f1e0b6a2