### PR TITLE
Configure module resolver alias

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,18 @@
+module.exports = function (api) {
+  api.cache(true);
+
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'expo-router/babel',
+      [
+        'module-resolver',
+        {
+          alias: {
+            '@': './',
+          },
+        },
+      ],
+    ],
+  };
+};

--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@expo/ngrok": "^4.1.0",
+        "babel-plugin-module-resolver": "^5.0.0",
         "@types/react": "~19.0.10",
         "eslint": "^9.31.0",
         "eslint-config-expo": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@expo/ngrok": "^4.1.0",
+    "babel-plugin-module-resolver": "^5.0.0",
     "@types/react": "~19.0.10",
     "eslint": "^9.31.0",
     "eslint-config-expo": "^9.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
 module.exports = async function (env, argv) {
@@ -8,6 +9,7 @@ module.exports = async function (env, argv) {
     ...config.resolve.alias,
     'lottie-react-native': './lottie-react-native.web.js',
     '@lottiefiles/dotlottie-react': './dotlottie-react.web.js',
+    '@': path.resolve(__dirname, '.'),
   };
   
   return config;


### PR DESCRIPTION
## Summary
- add `babel-plugin-module-resolver` as a dev dependency so the project can resolve project-root aliases
- create a Babel config that enables `babel-preset-expo`, `expo-router/babel`, and the `@` alias
- extend the webpack alias map to mirror the new `@` root alias for web builds

## Testing
- `bun run lint` *(fails: expo CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2ab2870c832eb8b6ff556d1b2a43